### PR TITLE
gh-94: Fixed values of unit tests

### DIFF
--- a/tests/test_EuclidLikelihood_SpectroscopicPowerSpectra.py
+++ b/tests/test_EuclidLikelihood_SpectroscopicPowerSpectra.py
@@ -248,7 +248,7 @@ def test_likelihood_value(data_setup, settings_setup):
 
     computed_loglike = likelihood.loglike(parameters)
 
-    expected_loglike = -8466.508
+    expected_loglike = -8481.404
     assert computed_loglike == pytest.approx(expected_loglike, rel=1e-5), (
         f"Expected log-likelihood to be approximately {expected_loglike}, "
         f"but got {computed_loglike}"
@@ -282,7 +282,7 @@ def test_likelihood_value_with_AM(data_setup, settings_setup, AM_priors_setup):
 
     computed_loglike = likelihood.loglike_AM(parameters)
 
-    expected_loglike = -113.5379
+    expected_loglike = -113.8038
     assert computed_loglike == pytest.approx(expected_loglike, rel=1e-5), (
         f"Expected log-likelihood to be approximately {expected_loglike}, "
         f"but got {computed_loglike}"


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

The values of the unit tests for the spectro module have been changed after a new version of comet has been released (which was leading to a breaking of the unit tests)

### 🔄 Changes

- [ ] changed values of unit tests

### 🏗 Related Issues

- Resolves #94

---

### ✅ PR Checklist for Developers

- [ ] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [ ] I have run locally pre-commit using `pre-commit run --all-files`
- [ ] I have tested my changes locally
- [ ] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [ ] My changes do not introduce breaking changes
- [ ] I have added tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [ ] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] No data files have been included in the commits
- [ ] Implementation follows the agreed task description point by point
- [ ] Check that there are no `No newline at the end of file` warnings
- [ ] Check that any added folder/file has been added to the `README.md` file
- [ ] Check that the documentation has been updated accordantly
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
