### PR TITLE
gh-91:  fixing CAMB and CLASS NonLinearPerturbations interface issue

### DIFF
--- a/cloelike/EuclidLikelihood_photo_Cls.py
+++ b/cloelike/EuclidLikelihood_photo_Cls.py
@@ -69,6 +69,9 @@ class WLMixin:
             }
         )
         lp = self.LinPerturbations(background, self.zs)
+        # lp is passed as the second argument for interface compatibility with
+        # emulator-based NonLinPerturbations classes; CAMB-based implementations
+        # accept but ignore it (nonlinear corrections are computed internally).
         nlp = self.NonLinPerturbations(
             background, lp, self.zs, log10TAGN=parameters["log10TAGN"]
         )
@@ -152,6 +155,9 @@ class GCphMixin:
             }
         )
         lp = self.LinPerturbations(background, self.zs)
+        # lp is passed as the second argument for interface compatibility with
+        # emulator-based NonLinPerturbations classes; CAMB-based implementations
+        # accept but ignore it (nonlinear corrections are computed internally).
         nlp = self.NonLinPerturbations(
             background, lp, self.zs, log10TAGN=parameters["log10TAGN"]
         )
@@ -244,6 +250,9 @@ class GGLMixin:
             }
         )
         lp = self.LinPerturbations(background, self.zs)
+        # lp is passed as the second argument for interface compatibility with
+        # emulator-based NonLinPerturbations classes; CAMB-based implementations
+        # accept but ignore it (nonlinear corrections are computed internally).
         nlp = self.NonLinPerturbations(
             background, lp, self.zs, log10TAGN=parameters["log10TAGN"]
         )

--- a/cloelike/EuclidLikelihood_photo_Cls.py
+++ b/cloelike/EuclidLikelihood_photo_Cls.py
@@ -69,9 +69,8 @@ class WLMixin:
             }
         )
         lp = self.LinPerturbations(background, self.zs)
-        # lp is passed as the second argument for interface compatibility with
-        # emulator-based NonLinPerturbations classes; CAMB-based implementations
-        # accept but ignore it (nonlinear corrections are computed internally).
+        # lp is passed as the second argument for interface compatibility
+        # CAMB and CLASS-based implementations accept but ignore it (nonlinear corrections are computed internally).
         nlp = self.NonLinPerturbations(
             background, lp, self.zs, log10TAGN=parameters["log10TAGN"]
         )


### PR DESCRIPTION


## 🚀 Pull Request Checklist

### ✅ Summary

`cloelike` calls `NonLinPerturbations` with the signature `(background, linearperturbations, redshifts, log10TAGN)` to support emulator-based classes that compute nonlinear boosts from pre-computed linear power spectra. The `linearperturbations` argument was not documented at the call sites, making it unclear why it is passed — especially for CAMB-based implementations that accept but do not use it. This PR adds inline comments explaining the interface contract.


### 🔄 Changes

- [x] Added inline comments at all 3 `NonLinPerturbations` call sites in `EuclidLikelihood_photo_Cls.py` explaining that `lp` is passed for interface compatibility and is accepted but unused by CAMB-based implementations


### 🛠 How to Test

```python
from cloelib.cosmology.camb_cosmology import CAMBBackground, CAMBLinearPerturbations, CAMBNonLinearPerturbations
import numpy as np

bg = CAMBBackground(H0=67.0, Omega_b0=0.049, Omega_cdm0=0.270, Omega_k0=0.0,
                    As=2.1e-9, ns=0.96, mnu=0.06, w0=-1.0, wa=0.0,
                    gamma_MG=0.0, N_mnu=1)
zs = np.linspace(0.01, 2.0, 10)
lp = CAMBLinearPerturbations(bg, zs)
nlp = CAMBNonLinearPerturbations(bg, lp, zs)
print(nlp.sigma8_0())  # expected: ~0.816
```


### 📝 Documentation

- [x] This PR updates documentation


### 🏗 Related Issues


- Resolves #91 


### 📌 Additional Notes

- Companion PR to the cloelib fix that added `linearperturbations` to `CAMBNonLinearPerturbations.__init__`

---

### ✅ PR Checklist for Developers

- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] I have run locally pre-commit using `pre-commit run --all-files`
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [x] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes
- [x] I have added tests (if applicable)
- [x] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [ ] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] No data files have been included in the commits
- [ ] Implementation follows the agreed task description point by point
- [ ] Check that there are no `No newline at the end of file` warnings
- [ ] Check that any added folder/file has been added to the `README.md` file
- [ ] Check that the documentation has been updated accordantly
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
